### PR TITLE
assure that new bug-corrected version of SeBa is downloaded (see SeBa…

### DIFF
--- a/src/amuse/community/seba/download.py
+++ b/src/amuse/community/seba/download.py
@@ -93,7 +93,10 @@ def new_option_parser():
     result = OptionParser()
     result.add_option(
         "--seba-version",
-        default='2d8088ad03a4323514780e19e5895fbcac42e0ec',
+        #default='2d8088ad03a4323514780e19e5895fbcac42e0ec',
+        #default='9fb5af99199b369f58be9a18a1d023e960d923d4',
+        default='a6f4b64f852249a0b66d52aa6f276be517dccb64',
+
         dest="seba_version",
         help="SeBa commit hash to download",
         type="string"

--- a/src/amuse/community/seba/interface.cc
+++ b/src/amuse/community/seba/interface.cc
@@ -42,8 +42,8 @@ local void addbinary(
 
             id = bi->get_index();
 
-            // cerr << "Adding binary to "<< id << " at time = "
-            //      << stellar_time << endl;
+            cerr << "Adding binary to "<< id << " at time = "
+                 << stellar_time << endl;
 
             double_star* new_double
             = new_double_star(bi, sma, ecc, stellar_time, id, type);
@@ -53,7 +53,8 @@ local void addbinary(
             // Give the new binary the old star_story.
 
             new_double->set_star_story(old_story);
-
+	    // Assure that SeBa prints zero-age binary parameters (SPZ+FK Febr2025).
+	    new_double->dump("SeBa.data", true);
             
         }
         else {
@@ -456,7 +457,7 @@ int new_particle(int * index_of_the_star, double mass){
         new_node->set_elder_sister(seba_insertion_point);
         seba_insertion_point = new_node;
     }
-    
+
     addstar(new_node, seba_time, start_type, seba_metallicity, 0, false);
     new_node->get_starbase()->set_time_offset(seba_time);
     *index_of_the_star = next_seba_id;
@@ -919,6 +920,15 @@ int new_binary(
     child2->set_elder_sister(child1);
     child1->set_parent(new_node);
     child2->set_parent(new_node);
+    // We cannot access the stellar parameters from here, because the starbase class is in between.
+    // SPZ*FK Febr.2025
+    //cerr << "Set stelar id in new binary interface."<<endl;
+    //cerr << "Current interface "<< child1->get_star_id()<<"and "<< child1->get_star_id()<<endl;
+    //child2->set_star_id(1);
+    // set stellar id's
+    //child1->set_star_id(0);
+    //child2->set_star_id(1);
+    
     
     addbinary(new_node, seba_time, binary_start_type, semi_major_axis, eccentricity);
     


### PR DESCRIPTION
… issue a6f4), and make SeBa interface print zero-age binary parameters.